### PR TITLE
Gather info from nested inner exceptions to show it

### DIFF
--- a/Up2dateService/Up2dateConsole/Dialogs/RequestCertificateDialogViewModel.cs
+++ b/Up2dateService/Up2dateConsole/Dialogs/RequestCertificateDialogViewModel.cs
@@ -62,12 +62,14 @@ namespace Up2dateConsole.Dialogs
 
         private async Task ExecuteRequestAsync()
         {
+            IsInProgress = true;
+
             IWcfService service = null;
             string error = string.Empty;
             try
             {
                 service = wcfClientFactory.CreateClient();
-                ResultOfstring result = service.RequestCertificate(RemoveWhiteSpaces(OneTimeKey));
+                ResultOfstring result = await service.RequestCertificateAsync(RemoveWhiteSpaces(OneTimeKey));
                 if (!result.Success)
                 {
                     error = result.ErrorMessage;
@@ -84,6 +86,7 @@ namespace Up2dateConsole.Dialogs
             finally
             {
                 wcfClientFactory.CloseClient(service);
+                IsInProgress = false;
             }
 
             if (string.IsNullOrEmpty(error))
@@ -125,6 +128,5 @@ namespace Up2dateConsole.Dialogs
             {
             }
         }
-
     }
 }

--- a/Up2dateService/Up2dateConsole/MainWindow.xaml
+++ b/Up2dateService/Up2dateConsole/MainWindow.xaml
@@ -149,10 +149,10 @@
                                         <TextBlock.Style>
                                             <Style x:Uid="Style_4" TargetType="{x:Type TextBlock}">
                                                 <Style.Triggers>
-                                                    <DataTrigger x:Uid="DataTrigger_1" Binding="{Binding Package?.Status}" Value="{x:Static service:PackageStatus.Failed}">
+                                                    <DataTrigger x:Uid="DataTrigger_1" Binding="{Binding PackageStatus}" Value="{x:Static service:PackageStatus.Failed}">
                                                         <Setter x:Uid="Setter_6" Property="Foreground" Value="Red"/>
                                                     </DataTrigger>
-                                                    <DataTrigger x:Uid="DataTrigger_2" Binding="{Binding Package?.Status}" Value="{x:Static service:PackageStatus.Installed}">
+                                                    <DataTrigger x:Uid="DataTrigger_2" Binding="{Binding PackageStatus}" Value="{x:Static service:PackageStatus.Installed}">
                                                         <Setter x:Uid="Setter_7" Property="Foreground" Value="Green"/>
                                                     </DataTrigger>
                                                 </Style.Triggers>

--- a/Up2dateService/Up2dateConsole/PackageItem.cs
+++ b/Up2dateService/Up2dateConsole/PackageItem.cs
@@ -21,6 +21,8 @@ namespace Up2dateConsole
 
         public string Filename => Path.GetFileName(Package.Filepath);
 
+        public PackageStatus PackageStatus => Package.Status;
+
         public string Status => statusToString(Package.Status);
 
         public string ExtraInfo => Package.ErrorCode == InstallPackageResult.Success ? null : $"ErrorCode: {Package.ErrorCode}";

--- a/Up2dateService/Up2dateService/WcfService.cs
+++ b/Up2dateService/Up2dateService/WcfService.cs
@@ -88,7 +88,7 @@ namespace Up2dateService
             }
             catch (Exception e)
             {
-                return Result<string>.Failed(e.Message);
+                return Result<string>.Failed(e);
             }
             return Result<string>.Successful(GetDeviceId());
         }

--- a/Up2dateService/Up2dateShared/Result.cs
+++ b/Up2dateService/Up2dateShared/Result.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
+using System.Text;
 
 namespace Up2dateShared
 {
@@ -32,6 +34,17 @@ namespace Up2dateShared
         public static Result<T> Failed(string errorMessage = null)
         {
             return new Result<T> { Success = false, ErrorMessage = errorMessage };
+        }
+
+        public static Result<T> Failed(Exception exception)
+        {
+            var msgBuilder = new StringBuilder();
+            for (var e = exception; e != null; e = e.InnerException)
+            {
+                if (e is AggregateException) continue;
+                msgBuilder.AppendLine(e.Message);
+            }
+            return new Result<T> { Success = false, ErrorMessage = msgBuilder.ToString() };
         }
 
         [DataMember]


### PR DESCRIPTION
Fixes #70 

## Proposed Changes

  - Gather info from nested inner exceptions to show it in the error message box.
  - Use async variant of RequestCertificate method and show spinner while the method executing.
