### PR TITLE
89 request - implement support for maintenance window deployment

### DIFF
--- a/Up2dateService/SimpleClientApp/Program.cs
+++ b/Up2dateService/SimpleClientApp/Program.cs
@@ -13,7 +13,7 @@ namespace SimpleClientApp
 
         static void Main(string[] args)
         {
-            var client = new Client(new SettingsManagerStub(), GetCertificate, new SetupManagerStub(), SystemInfo.Retrieve, GetCreatePackagesFolder, new LoggerStub("Client"));
+            var client = new Client(new SettingsManagerStub(), GetCertificate, new SetupManagerStub(), SystemInfo.Retrieve, new LoggerStub("Client"));
             client.Run();
         }
 

--- a/Up2dateService/SimpleClientApp/SetupManagerStub.cs
+++ b/Up2dateService/SimpleClientApp/SetupManagerStub.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Up2dateShared;
 
 namespace SimpleClientApp
@@ -7,9 +8,24 @@ namespace SimpleClientApp
     {
         public IEnumerable<string> SupportedExtensions => new[] { ".msi", ".nuget" };
 
+        public Result DownloadPackage(string artifactFileName, string artifactFileHashMd5, Action<string> downloadArtifact)
+        {
+            return Result.Successful();
+        }
+
         public List<Package> GetAvaliablePackages()
         {
             return new List<Package>();
+        }
+
+        public InstallPackageResult GetInstallPackageResult(string artifactFileName)
+        {
+            return InstallPackageResult.Success;
+        }
+
+        public PackageStatus GetStatus(string artifactFileName)
+        {
+            return PackageStatus.Unavailable;
         }
 
         public InstallPackageResult InstallPackage(string packageFile)
@@ -29,7 +45,7 @@ namespace SimpleClientApp
 
         public bool IsFileSupported(string artifactFileName)
         {
-            throw new System.NotImplementedException();
+            return true;
         }
 
         public bool IsPackageAvailable(string packageFile)
@@ -43,14 +59,6 @@ namespace SimpleClientApp
         }
 
         public void MarkPackageAsSuggested(string artifactFileName)
-        {
-        }
-
-        public void OnDownloadFinished(string artifactFileName)
-        {
-        }
-
-        public void OnDownloadStarted(string artifactFileName)
         {
         }
     }

--- a/Up2dateService/Up2dateClient/Client.cs
+++ b/Up2dateService/Up2dateClient/Client.cs
@@ -41,7 +41,8 @@ namespace Up2dateClient
         }
 
         public void Run()
-        {            IntPtr dispatcher = IntPtr.Zero;
+        {            
+            IntPtr dispatcher = IntPtr.Zero;
             try
             {
                 string cert = getCertificate();
@@ -104,8 +105,10 @@ namespace Up2dateClient
                 WriteLogEntry(message, info);
             }
 
-            ClientResult MakeResult(Finished finished, Execution execution)
+            ClientResult LogAndMakeResult(Finished finished, Execution execution, string message)
             {
+                LogMessage(message);
+
                 return new ClientResult
                 {
                     Message = messageBuilder.ToString(),
@@ -118,22 +121,19 @@ namespace Up2dateClient
 
             if (!IsExtensionAllowed(info))
             {
-                LogMessage("Package type is not allowed - deployment rejected.");
-                result = MakeResult(Finished.FAILURE, Execution.CLOSED);
+                result = LogAndMakeResult(Finished.FAILURE, Execution.CLOSED, "Package type is not allowed - deployment rejected.");
                 return;
             }
 
             if (!IsSupported(info))
             {
-                LogMessage("Package type is not supported - deployment rejected.");
-                result = MakeResult(Finished.FAILURE, Execution.CLOSED);
+                result = LogAndMakeResult(Finished.FAILURE, Execution.CLOSED , "Package type is not allowed - deployment rejected.");
                 return;
             }
 
             if (lastStopID == info.id)
             {
-                LogMessage("Deployment action is cancelled.");
-                result = MakeResult(Finished.NONE, Execution.CANCELED);
+                result = LogAndMakeResult(Finished.NONE, Execution.CANCELED, "Deployment action is cancelled.");
                 lastStopID = -1;
                 return;
             }
@@ -153,8 +153,7 @@ namespace Up2dateClient
                 }
                 catch (Exception)
                 {
-                    LogMessage("Download failed");
-                    result = MakeResult(Finished.FAILURE, Execution.CLOSED);
+                    result = LogAndMakeResult(Finished.FAILURE, Execution.CLOSED, "Download failed");
                     return;
                 }
                 finally
@@ -167,81 +166,82 @@ namespace Up2dateClient
 
             if (setupManager.IsPackageInstalled(info.artifactFileName))
             {
-                LogMessage("Package has been already installed.");
-                result = MakeResult(Finished.SUCCESS, Execution.CLOSED);
+                result = LogAndMakeResult(Finished.SUCCESS, Execution.CLOSED, "Package has been already installed.");
                 return;
             }
 
             switch (info.updateType)
             {
                 case "skip":
-                    if (info.isInMaintenanceWindow)
-                    {
-                        LogMessage("Only download is requested.");
-                        result = MakeResult(Finished.SUCCESS, Execution.CLOSED);
-                    }
-                    else
-                    {
-                        LogMessage("Waiting for maintenance window to start installation.");
-                        result = MakeResult(Finished.NONE, Execution.SCHEDULED);
-                    }
+                    result = info.isInMaintenanceWindow 
+                        ? LogAndMakeResult(Finished.SUCCESS, Execution.CLOSED, "Only download is requested.")
+                        : LogAndMakeResult(Finished.NONE, Execution.SCHEDULED, "Waiting for maintenance window to start installation.");
                     return;
                 case "attempt":
-                    LogMessage("Installation is not forced.");
-                    setupManager.MarkPackageAsSuggested(info.artifactFileName);
-                    result = MakeResult(Finished.NONE, Execution.SCHEDULED);
-                    return;
+                    {
+                        PackageStatus status = setupManager.GetStatus(info.artifactFileName);
+                        if (status == PackageStatus.Failed)
+                        {
+                            InstallPackageResult installPackageResult = setupManager.GetInstallPackageResult(info.artifactFileName);
+                            result = LogAndMakeResult(Finished.FAILURE, Execution.CLOSED, ResultToMessage(installPackageResult));
+                            return;
+                        }
+                        setupManager.MarkPackageAsSuggested(info.artifactFileName);
+                        result = LogAndMakeResult(Finished.NONE, Execution.SCHEDULED, "Installation is not forced; suggested to user.");
+                        return;
+                    }
                 case "forced":
-                    LogMessage("Installation is forced.");
+                    {
+                        LogMessage("Forced installation started.");
+                        setupManager.InstallPackage(info.artifactFileName);
+                        PackageStatus status = setupManager.GetStatus(info.artifactFileName);
+                        if (status == PackageStatus.Failed)
+                        {
+                            InstallPackageResult installPackageResult = setupManager.GetInstallPackageResult(info.artifactFileName);
+                            result = LogAndMakeResult(Finished.FAILURE, Execution.CLOSED, ResultToMessage(installPackageResult));
+                            return;
+                        }
+                        result = LogAndMakeResult(Finished.SUCCESS, Execution.CLOSED, "Installation completed.");
+                        return;
+                    }
+                default:
+                    result = LogAndMakeResult(Finished.FAILURE, Execution.REJECTED, $"Unsupported update type: {info.updateType}, request rejected.");
+                    return;
+            }
+        }
+
+        private string ResultToMessage(InstallPackageResult installPackageStatus)
+        {
+            string message = "Installation failed. ";
+            switch (installPackageStatus)
+            {
+                case InstallPackageResult.PackageUnavailable:
+                    message += "Package unavailable or unusable";
+                    break;
+                case InstallPackageResult.FailedToInstallChocoPackage:
+                    message += "Failed to install Choco package";
+                    break;
+                case InstallPackageResult.ChocoNotInstalled:
+                    message += "Chocolatey is not installed";
+                    break;
+                case InstallPackageResult.GeneralInstallationError:
+                    message += "General installation error";
+                    break;
+                case InstallPackageResult.SignatureVerificationFailed:
+                    message += "Signature verification for the package is failed. " +
+                        $"Requested level: {settingsManager.SignatureVerificationLevel}. Deployment rejected";
+                    break;
+                case InstallPackageResult.PackageNotSupported:
+                    message += "Package of this type is not supported";
+                    break;
+                case InstallPackageResult.CannotStartInstaller:
+                    message += "Failed to start installer process";
                     break;
                 default:
-                    LogMessage($"Unsupported update type: {info.updateType}, request rejected.");
-                    result = MakeResult(Finished.FAILURE, Execution.REJECTED);
-                    return;
+                    throw new ArgumentOutOfRangeException();
             }
 
-            LogMessage("Installation started.");
-
-            InstallPackageResult installPackageStatus = setupManager.InstallPackage(info.artifactFileName);
-            if (installPackageStatus != InstallPackageResult.Success && installPackageStatus != InstallPackageResult.RestartNeeded)
-            {
-                string message = "Installation failed. ";
-                switch (installPackageStatus)
-                {
-                    case InstallPackageResult.PackageUnavailable:
-                        message += "Package unavailable or unusable";
-                        break;
-                    case InstallPackageResult.FailedToInstallChocoPackage:
-                        message += "Failed to install Choco package";
-                        break;
-                    case InstallPackageResult.ChocoNotInstalled:
-                        message += "Chocolatey is not installed";
-                        break;
-                    case InstallPackageResult.GeneralInstallationError:
-                        message += "General installation error";
-                        break;
-                    case InstallPackageResult.SignatureVerificationFailed:
-                        message += "Signature verification for the package is failed. " +
-                            $"Requested level: {settingsManager.SignatureVerificationLevel}. Deployment rejected";
-                        break;
-                    case InstallPackageResult.PackageNotSupported:
-                        message += "Package of this type is not supported";
-                        break;
-                    case InstallPackageResult.CannotStartInstaller:
-                        message += "Failed to start installer process";
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-
-                LogMessage(message);
-                result = MakeResult(Finished.FAILURE, Execution.CLOSED);
-            }
-            else
-            {
-                LogMessage("Installation completed.");
-                result = MakeResult(Finished.SUCCESS, Execution.CLOSED);
-            }
+            return message;
         }
 
         private bool IsExtensionAllowed(DeploymentInfo info)

--- a/Up2dateService/Up2dateClient/Client.cs
+++ b/Up2dateService/Up2dateClient/Client.cs
@@ -15,17 +15,15 @@ namespace Up2dateClient
         private readonly Func<string> getCertificate;
         private readonly ISetupManager setupManager;
         private readonly Func<SystemInfo> getSysInfo;
-        private readonly Func<string> getDownloadLocation;
         private ClientState state;
         private int lastStopID = -1;
 
-        public Client(ISettingsManager settingsManager, Func<string> getCertificate, ISetupManager setupManager, Func<SystemInfo> getSysInfo, Func<string> getDownloadLocation, ILogger logger)
+        public Client(ISettingsManager settingsManager, Func<string> getCertificate, ISetupManager setupManager, Func<SystemInfo> getSysInfo, ILogger logger)
         {
             this.settingsManager = settingsManager ?? throw new ArgumentNullException(nameof(settingsManager));
             this.getCertificate = getCertificate ?? throw new ArgumentNullException(nameof(getCertificate));
             this.setupManager = setupManager ?? throw new ArgumentNullException(nameof(setupManager));
             this.getSysInfo = getSysInfo ?? throw new ArgumentNullException(nameof(getSysInfo));
-            this.getDownloadLocation = getDownloadLocation ?? throw new ArgumentNullException(nameof(getDownloadLocation));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 

--- a/Up2dateService/Up2dateClient/Client.cs
+++ b/Up2dateService/Up2dateClient/Client.cs
@@ -145,22 +145,12 @@ namespace Up2dateClient
             else
             {
                 LogMessage("Download started.");
-
-                setupManager.OnDownloadStarted(info.artifactFileName);
-                try
+                Result downloadResult = setupManager.DownloadPackage(info.artifactFileName, info.artifactFileHashMd5, location => Wrapper.DownloadArtifact(artifact, location));
+                if (!downloadResult.Success)
                 {
-                    Wrapper.DownloadArtifact(artifact, getDownloadLocation());
-                }
-                catch (Exception)
-                {
-                    result = LogAndMakeResult(Finished.FAILURE, Execution.CLOSED, "Download failed");
+                    result = LogAndMakeResult(Finished.FAILURE, Execution.CLOSED, $"Download failed. {downloadResult.ErrorMessage}");
                     return;
                 }
-                finally
-                {
-                    setupManager.OnDownloadFinished(info.artifactFileName);
-                }
-
                 LogMessage("Download completed.");
             }
 

--- a/Up2dateService/Up2dateClient/Client.cs
+++ b/Up2dateService/Up2dateClient/Client.cs
@@ -175,8 +175,16 @@ namespace Up2dateClient
             switch (info.updateType)
             {
                 case "skip":
-                    LogMessage("Installation is not requested.");
-                    result = MakeResult(Finished.SUCCESS, Execution.CLOSED);
+                    if (info.isInMaintenanceWindow)
+                    {
+                        LogMessage("Only download is requested.");
+                        result = MakeResult(Finished.SUCCESS, Execution.CLOSED);
+                    }
+                    else
+                    {
+                        LogMessage("Waiting for maintenance window to start installation.");
+                        result = MakeResult(Finished.NONE, Execution.SCHEDULED);
+                    }
                     return;
                 case "attempt":
                     LogMessage("Installation is not forced.");

--- a/Up2dateService/Up2dateClient/DeploymentInfo.cs
+++ b/Up2dateService/Up2dateClient/DeploymentInfo.cs
@@ -1,11 +1,14 @@
-﻿namespace Up2dateClient
+﻿using System.Runtime.InteropServices;
+
+namespace Up2dateClient
 {
+    [StructLayout(LayoutKind.Sequential)]
     public struct DeploymentInfo
     {
         public int id;
         public string updateType;
         public string downloadType;
-        public bool isInMaintenanceWindow;
+        [MarshalAs(UnmanagedType.I1)] public bool isInMaintenanceWindow;
         public string chunkPart;
         public string chunkName;
         public string chunkVersion;

--- a/Up2dateService/Up2dateService/Service.cs
+++ b/Up2dateService/Up2dateService/Service.cs
@@ -38,8 +38,7 @@ namespace Up2dateService
             IPackageValidatorFactory validatorFactory = new PackageValidatorFactory(settingsManager, signatureVerifier, whiteListManager);
             ISetupManager setupManager = new SetupManager.SetupManager(new Logger(EventLog, nameof(SetupManager)), GetCreatePackagesFolder, settingsManager, installerFactory, validatorFactory);
 
-            Client client = new Client(settingsManager, certificateManager.GetCertificateString, setupManager, SystemInfo.Retrieve,
-                GetCreatePackagesFolder, new Logger(EventLog, nameof(Client)));
+            Client client = new Client(settingsManager, certificateManager.GetCertificateString, setupManager, SystemInfo.Retrieve, new Logger(EventLog, nameof(Client)));
 
             WcfService wcfService = new WcfService(setupManager, SystemInfo.Retrieve, GetCreatePackagesFolder, () => client.State,
                 certificateProvider, certificateManager, settingsManager, signatureVerifier, whiteListManager);

--- a/Up2dateService/Up2dateShared/ISetupManager.cs
+++ b/Up2dateService/Up2dateShared/ISetupManager.cs
@@ -13,5 +13,7 @@ namespace Up2dateShared
         bool IsFileDownloaded(string artifactFileName, string artifactFileHashMd5);
         bool IsPackageInstalled(string artifactFileName);
         void MarkPackageAsSuggested(string artifactFileName);
+        PackageStatus GetStatus(string artifactFileName);
+        InstallPackageResult GetInstallPackageResult(string artifactFileName);
     }
 }

--- a/Up2dateService/Up2dateShared/ISetupManager.cs
+++ b/Up2dateService/Up2dateShared/ISetupManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Up2dateShared
 {
@@ -7,13 +8,12 @@ namespace Up2dateShared
         List<Package> GetAvaliablePackages();
         InstallPackageResult InstallPackage(string packageFile);
         void InstallPackages(IEnumerable<Package> packages);
-        void OnDownloadStarted(string artifactFileName);
-        void OnDownloadFinished(string artifactFileName);
         bool IsFileSupported(string artifactFileName);
         bool IsFileDownloaded(string artifactFileName, string artifactFileHashMd5);
         bool IsPackageInstalled(string artifactFileName);
         void MarkPackageAsSuggested(string artifactFileName);
         PackageStatus GetStatus(string artifactFileName);
         InstallPackageResult GetInstallPackageResult(string artifactFileName);
+        Result DownloadPackage(string artifactFileName, string artifactFileHashMd5, Action<string> downloadArtifact);
     }
 }


### PR DESCRIPTION
Fixes #89 

## Proposed Changes

  - Don't close deployment action if request is out of maintenance window
  - Close deployment action is case of manual installation failure; this is needed to handle failures of "suggested" (soft) installation
  - Check MD5 after artifact download
  - Check MD5 before skipping download when artifact is already available
  - Refactor - move download logic from Client to SetupManager
