### PR TITLE
Fix bug - Console restarts on quit

### DIFF
--- a/Up2dateService/Up2dateConsole/App.xaml
+++ b/Up2dateService/Up2dateConsole/App.xaml
@@ -1,8 +1,7 @@
 ﻿<Application x:Uid="Application_1" x:Class="Up2dateConsole.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
-             StartupUri="MainWindow.xaml">
+             xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <Application.Resources>
         <FontFamily x:Uid="FontFamily_1" x:Key="FontAwesome">/fonts/fontawesome-webfont.ttf#FontAwesome</FontFamily>
 

--- a/Up2dateService/Up2dateConsole/App.xaml.cs
+++ b/Up2dateService/Up2dateConsole/App.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Toolkit.Uwp.Notifications;
-using NLog;
 using System;
 using System.Diagnostics;
 using System.Reflection;
@@ -16,13 +15,11 @@ namespace Up2dateConsole
 {
     public partial class App
     {
-        private static Logger logger = LogManager.GetCurrentClassLogger();
+        private static Logger logger = new Logger();
 
         protected override void OnStartup(StartupEventArgs e)
         {
-            Debugger.Launch(); // todo remove for production
-
-            SetupExceptionHandling();
+            //Debugger.Launch(); // todo remove for production
 
             if (Up2dateConsole.Properties.Settings.Default.UpgradeFlag)
             {
@@ -42,8 +39,6 @@ namespace Up2dateConsole
                 return;
             }
 
-            MainWindow = CreateMainWindow();
-
             var suppressGuard = CommandLineHelper.IsPresent(CommandLineHelper.AllowSecondInstanceCommand);
             new SingleInstanceHelper(this, ShowMainWindow).Guard(suppressGuard);
 
@@ -51,10 +46,14 @@ namespace Up2dateConsole
 
             ToastNotificationManagerCompat.OnActivated += ToastNotificationManagerCompat_OnActivated;
 
+            MainWindow = CreateMainWindow();
+
             if (CommandLineHelper.IsPresent(CommandLineHelper.VisibleMainWindowCommand))
             {
                 MainWindow.Show();
             }
+
+            SetupExceptionHandling();
         }
 
         private Window CreateMainWindow()

--- a/Up2dateService/Up2dateConsole/App.xaml.cs
+++ b/Up2dateService/Up2dateConsole/App.xaml.cs
@@ -21,8 +21,6 @@ namespace Up2dateConsole
         protected override void OnStartup(StartupEventArgs e)
         {
             //Debugger.Launch(); // todo remove for production
-            logger.Info("Console start.");
-
             if (Up2dateConsole.Properties.Settings.Default.UpgradeFlag)
             {
                 logger.Info("First start after installation or upgrade - upgrading settings.");
@@ -68,7 +66,7 @@ namespace Up2dateConsole
 
             IWcfClientFactory wcfClientFactory = new WcfClientFactory();
             ISettings settings = new Settings();
-            var session = new Session.Session(new HookMonitor(false), settings);
+            ISession session = new Session.Session(new HookMonitor(false), settings);
             mainWindow.DataContext = new MainWindowViewModel(viewService, wcfClientFactory, settings, session);
 
             mainWindow.Closing += (w, e) =>
@@ -77,6 +75,15 @@ namespace Up2dateConsole
                 ((Window)w).Hide();
                 e.Cancel = true;
             };
+
+            SessionEnding += (w, e) =>
+            {
+                logger.Info($"Console exiting due to {e.ReasonSessionEnding}");
+                session.OnWindowsSessionEnding();
+            };
+
+            string mode = session.IsAdminMode ? "Admin" : "User";
+            logger.Info($"Console started in {mode} mode");
 
             return mainWindow;
         }

--- a/Up2dateService/Up2dateConsole/App.xaml.cs
+++ b/Up2dateService/Up2dateConsole/App.xaml.cs
@@ -20,7 +20,10 @@ namespace Up2dateConsole
 
         protected override void OnStartup(StartupEventArgs e)
         {
-            //Debugger.Launch(); // todo remove for production
+            Debugger.Launch(); // todo remove for production
+
+            SetupExceptionHandling();
+
             if (Up2dateConsole.Properties.Settings.Default.UpgradeFlag)
             {
                 logger.Info("First start after installation or upgrade - upgrading settings.");
@@ -45,8 +48,6 @@ namespace Up2dateConsole
             new SingleInstanceHelper(this, ShowMainWindow).Guard(suppressGuard);
 
             base.OnStartup(e);
-
-            SetupExceptionHandling();
 
             ToastNotificationManagerCompat.OnActivated += ToastNotificationManagerCompat_OnActivated;
 

--- a/Up2dateService/Up2dateConsole/Localization/Up2dateConsole_ru-RU.csv
+++ b/Up2dateService/Up2dateConsole/Localization/Up2dateConsole_ru-RU.csv
@@ -485,6 +485,7 @@ Up2dateConsole.g.en-US.resources:texts.baml,clr:String_61:System.String.$Content
 Up2dateConsole.g.en-US.resources:texts.baml,clr:String_62:System.String.$Content,None,True,True,,"Не удалось установить соединение с сервером. Проверьте URL, ID устройства и токен.","Failed to establish server connection. Please check entered URL, device ID and token.",
 Up2dateConsole.g.en-US.resources:texts.baml,clr:String_63:System.String.$Content,None,True,True,,Соединение с сервером успешно установлено.,Server connection successfully established.,
 Up2dateConsole.g.en-US.resources:app.baml,Application_1:Up2dateConsole.App.$Content,None,True,True,,,,
+Up2dateConsole.g.en-US.resources:app.baml,Application_1:System.Windows.Application.ShutdownMode,None,True,False,,OnExplicitShutdown,OnExplicitShutdown,
 Up2dateConsole.g.en-US.resources:app.baml,FontFamily_1:System.Windows.Media.FontFamily.$Content,Font,True,True,,/fonts/fontawesome-webfont.ttf\#FontAwesome,/fonts/fontawesome-webfont.ttf\#FontAwesome,
 Up2dateConsole.g.en-US.resources:app.baml,Setter_1:System.Windows.Setter.Property,None,False,False,,ToolTipService.ShowDuration,ToolTipService.ShowDuration,
 Up2dateConsole.g.en-US.resources:app.baml,Setter_1:System.Windows.Setter.Value,None,False,True,,20000,20000,

--- a/Up2dateService/Up2dateConsole/Logger.cs
+++ b/Up2dateService/Up2dateConsole/Logger.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+
+namespace Up2dateConsole
+{
+    public class Logger
+    {
+        private readonly string filePath;
+
+        public Logger()
+        {
+            filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"Up2dateConsole\logs\Up2dateConsole.log");
+        }
+
+        public void Info(string message)
+        {
+            using (var fs = new StreamWriter(filePath, append: true))
+            {
+                fs.WriteLine($"{DateTime.Now} | INFO  | {message}");
+                fs.Flush();
+            }
+        }
+
+        public void Error(Exception e, string message)
+        {
+            using (var fs = new StreamWriter(filePath, append: true))
+            {
+                fs.WriteLine($"{DateTime.Now} | ERROR | {message}\n{e}");
+                fs.Flush();
+            }
+        }
+    }
+}

--- a/Up2dateService/Up2dateConsole/MainWindow.xaml.cs
+++ b/Up2dateService/Up2dateConsole/MainWindow.xaml.cs
@@ -20,7 +20,7 @@ namespace Up2dateConsole
 
             IWcfClientFactory wcfClientFactory = new WcfClientFactory();
             ISettings settings = new Settings();
-            DataContext = new MainWindowViewModel(viewService, wcfClientFactory, new HookMonitor(false), settings, Application.Current.Shutdown);
+            DataContext = new MainWindowViewModel(viewService, wcfClientFactory, new HookMonitor(false), settings, new Session.Session());
 
             if (!CommandLineHelper.IsPresent(CommandLineHelper.VisibleMainWindowCommand))
             {

--- a/Up2dateService/Up2dateConsole/MainWindow.xaml.cs
+++ b/Up2dateService/Up2dateConsole/MainWindow.xaml.cs
@@ -4,12 +4,15 @@ using Up2dateConsole.Dialogs.RequestCertificate;
 using Up2dateConsole.Dialogs.Settings;
 using Up2dateConsole.Helpers;
 using Up2dateConsole.Helpers.InactivityMonitor;
+using Up2dateConsole.Session;
 using Up2dateConsole.ViewService;
 
 namespace Up2dateConsole
 {
     public partial class MainWindow
     {
+        ISession session;
+
         public MainWindow()
         {
             InitializeComponent();
@@ -20,7 +23,8 @@ namespace Up2dateConsole
 
             IWcfClientFactory wcfClientFactory = new WcfClientFactory();
             ISettings settings = new Settings();
-            DataContext = new MainWindowViewModel(viewService, wcfClientFactory, new HookMonitor(false), settings, new Session.Session());
+            session = new Session.Session(new HookMonitor(false), settings);
+            DataContext = new MainWindowViewModel(viewService, wcfClientFactory, settings, session);
 
             if (!CommandLineHelper.IsPresent(CommandLineHelper.VisibleMainWindowCommand))
             {
@@ -30,8 +34,7 @@ namespace Up2dateConsole
 
         protected override void OnClosing(CancelEventArgs e)
         {
-            var viewModel = DataContext as MainWindowViewModel;
-            viewModel?.OnWindowClosing();
+            session.OnWindowClosing();
 
             Hide();
             e.Cancel = true;

--- a/Up2dateService/Up2dateConsole/MainWindow.xaml.cs
+++ b/Up2dateService/Up2dateConsole/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Windows;
 using Up2dateConsole.Dialogs.RequestCertificate;
 using Up2dateConsole.Dialogs.Settings;
 using Up2dateConsole.Helpers;
@@ -19,7 +20,7 @@ namespace Up2dateConsole
 
             IWcfClientFactory wcfClientFactory = new WcfClientFactory();
             ISettings settings = new Settings();
-            DataContext = new MainWindowViewModel(viewService, wcfClientFactory, new HookMonitor(false), settings);
+            DataContext = new MainWindowViewModel(viewService, wcfClientFactory, new HookMonitor(false), settings, Application.Current.Shutdown);
 
             if (!CommandLineHelper.IsPresent(CommandLineHelper.VisibleMainWindowCommand))
             {
@@ -30,11 +31,7 @@ namespace Up2dateConsole
         protected override void OnClosing(CancelEventArgs e)
         {
             var viewModel = DataContext as MainWindowViewModel;
-            if (viewModel != null && viewModel.IsAdminMode && Properties.Settings.Default.LeaveAdminModeOnClose)
-            {
-                viewModel.LeaveAdminModeCommand.Execute(this);
-                return;
-            }
+            viewModel?.OnWindowClosing();
 
             Hide();
             e.Cancel = true;

--- a/Up2dateService/Up2dateConsole/MainWindow.xaml.cs
+++ b/Up2dateService/Up2dateConsole/MainWindow.xaml.cs
@@ -1,44 +1,10 @@
-﻿using System.ComponentModel;
-using System.Windows;
-using Up2dateConsole.Dialogs.RequestCertificate;
-using Up2dateConsole.Dialogs.Settings;
-using Up2dateConsole.Helpers;
-using Up2dateConsole.Helpers.InactivityMonitor;
-using Up2dateConsole.Session;
-using Up2dateConsole.ViewService;
-
-namespace Up2dateConsole
+﻿namespace Up2dateConsole
 {
     public partial class MainWindow
     {
-        ISession session;
-
         public MainWindow()
         {
             InitializeComponent();
-
-            IViewService viewService = new ViewService.ViewService();
-            viewService.RegisterDialog(typeof(RequestCertificateDialogViewModel), typeof(RequestCertificateDialog));
-            viewService.RegisterDialog(typeof(SettingsDialogViewModel), typeof(SettingsDialog));
-
-            IWcfClientFactory wcfClientFactory = new WcfClientFactory();
-            ISettings settings = new Settings();
-            session = new Session.Session(new HookMonitor(false), settings);
-            DataContext = new MainWindowViewModel(viewService, wcfClientFactory, settings, session);
-
-            if (!CommandLineHelper.IsPresent(CommandLineHelper.VisibleMainWindowCommand))
-            {
-                Hide();
-            }
-        }
-
-        protected override void OnClosing(CancelEventArgs e)
-        {
-            session.OnWindowClosing();
-
-            Hide();
-            e.Cancel = true;
-            base.OnClosing(e);
         }
     }
 }

--- a/Up2dateService/Up2dateConsole/MainWindowViewModel.cs
+++ b/Up2dateService/Up2dateConsole/MainWindowViewModel.cs
@@ -73,7 +73,6 @@ namespace Up2dateConsole
         private void Session_ShuttingDown(object sender, EventArgs e)
         {
             timer.Stop();
-            //todo break all loops and wait for async tasks to complete
         }
 
         private async Task ExecuteStopService()
@@ -229,7 +228,11 @@ namespace Up2dateConsole
             {
                 await ThreadHelper.SafeInvokeAsync(ExecuteRefresh);
             }
-            timer.Start();
+
+            if (!session.IsShuttingDown)
+            {
+                timer.Start();
+            }
         }
 
         private async Task ExecuteRequestCertificateAsync()

--- a/Up2dateService/Up2dateConsole/MainWindowViewModel.cs
+++ b/Up2dateService/Up2dateConsole/MainWindowViewModel.cs
@@ -90,7 +90,7 @@ namespace Up2dateConsole
 
         public void OnWindowClosing()
         {
-            if (session.IsAdminMode && Properties.Settings.Default.LeaveAdminModeOnClose && !session.IsShuttingDown)
+            if (session.IsAdminMode && settings.LeaveAdminModeOnClose && !session.IsShuttingDown)
             {
                 session.ToUserMode();
             }
@@ -308,8 +308,8 @@ namespace Up2dateConsole
             const int MillisecondsInSecond = 1000;
             const int MinTimeoutSec = 5;
 
-            inactivityMonitor.Enabled = Properties.Settings.Default.LeaveAdminModeOnInactivity;
-            var timeout = Properties.Settings.Default.LeaveAdminModeOnInactivityTimeout;
+            inactivityMonitor.Enabled = settings.LeaveAdminModeOnInactivity;
+            var timeout = settings.LeaveAdminModeOnInactivityTimeout;
             if (timeout < MinTimeoutSec)
             {
                 timeout = MinTimeoutSec;

--- a/Up2dateService/Up2dateConsole/Session/ISession.cs
+++ b/Up2dateService/Up2dateConsole/Session/ISession.cs
@@ -8,6 +8,9 @@ namespace Up2dateConsole.Session
         void ToAdminMode();
         void ToUserMode();
         void Shutdown();
+        void OnSettingsUpdated();
+        void OnWindowClosing();
+
         bool IsAdminMode { get; }
         bool IsShuttingDown { get; }
     }

--- a/Up2dateService/Up2dateConsole/Session/ISession.cs
+++ b/Up2dateService/Up2dateConsole/Session/ISession.cs
@@ -10,6 +10,7 @@ namespace Up2dateConsole.Session
         void Shutdown();
         void OnSettingsUpdated();
         void OnWindowClosing();
+        void OnWindowsSessionEnding();
 
         bool IsAdminMode { get; }
         bool IsShuttingDown { get; }

--- a/Up2dateService/Up2dateConsole/Session/ISession.cs
+++ b/Up2dateService/Up2dateConsole/Session/ISession.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Up2dateConsole.Session
+{
+    public interface ISession
+    {
+        event EventHandler<EventArgs> ShuttingDown;
+        void ToAdminMode();
+        void ToUserMode();
+        void Shutdown();
+        bool IsAdminMode { get; }
+        bool IsShuttingDown { get; }
+    }
+}

--- a/Up2dateService/Up2dateConsole/Session/Session.cs
+++ b/Up2dateService/Up2dateConsole/Session/Session.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Security.Principal;
+using System.Windows;
+using Up2dateConsole.Helpers;
+
+namespace Up2dateConsole.Session
+{
+    public class Session : ISession
+    {
+        public event EventHandler<EventArgs> ShuttingDown;
+
+        public void Shutdown()
+        {
+            IsShuttingDown = true;
+            ShuttingDown?.Invoke(this, EventArgs.Empty);
+            Application.Current?.Shutdown();
+        }
+
+        public void ToAdminMode()
+        {
+            if (IsAdminMode) return;
+
+            using (Process p = new Process())
+            {
+                p.StartInfo.FileName = Assembly.GetEntryAssembly().Location;
+                p.StartInfo.Arguments = CommandLineHelper.AllowSecondInstanceCommand + " " + CommandLineHelper.VisibleMainWindowCommand;
+                p.StartInfo.Verb = "runas";
+
+                bool started = false;
+                try
+                {
+                    started = p.Start();
+                }
+                catch (Exception)
+                {
+                    started = false;
+                }
+
+                if (started)
+                {
+                    Shutdown();
+                }
+            }
+        }
+
+        public void ToUserMode()
+        {
+            if (!IsAdminMode) return;
+
+            ThreadHelper.SafeInvoke(() =>
+            {
+                Process.Start("explorer.exe", Assembly.GetEntryAssembly().Location);
+                Shutdown();
+            });
+        }
+
+        public bool IsAdminMode => new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
+
+        public bool IsShuttingDown { get; private set; }
+    }
+}

--- a/Up2dateService/Up2dateConsole/Session/Session.cs
+++ b/Up2dateService/Up2dateConsole/Session/Session.cs
@@ -2,14 +2,33 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Security.Principal;
+using System.Timers;
 using System.Windows;
 using Up2dateConsole.Helpers;
+using Up2dateConsole.Helpers.InactivityMonitor;
 
 namespace Up2dateConsole.Session
 {
     public class Session : ISession
     {
+        private readonly IInactivityMonitor inactivityMonitor;
+        private readonly ISettings settings;
+
         public event EventHandler<EventArgs> ShuttingDown;
+
+        public Session(IInactivityMonitor inactivityMonitor, ISettings settings)
+        {
+            this.inactivityMonitor = inactivityMonitor ?? throw new ArgumentNullException(nameof(inactivityMonitor));
+            this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
+
+            if (IsAdminMode)
+            {
+                inactivityMonitor.MonitorKeyboardEvents = true;
+                inactivityMonitor.MonitorMouseEvents = true;
+                inactivityMonitor.Elapsed += InactivityMonitor_Elapsed;
+                OnSettingsUpdated();
+            }
+        }
 
         public void Shutdown()
         {
@@ -59,5 +78,33 @@ namespace Up2dateConsole.Session
         public bool IsAdminMode => new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
 
         public bool IsShuttingDown { get; private set; }
+
+        public void OnSettingsUpdated()
+        {
+            const int MillisecondsInSecond = 1000;
+            const int MinTimeoutSec = 5;
+
+            inactivityMonitor.Enabled = settings.LeaveAdminModeOnInactivity;
+            var timeout = settings.LeaveAdminModeOnInactivityTimeout;
+            if (timeout < MinTimeoutSec)
+            {
+                timeout = MinTimeoutSec;
+            }
+            inactivityMonitor.Interval = timeout * MillisecondsInSecond;
+        }
+
+        public void OnWindowClosing()
+        {
+            if (IsAdminMode && settings.LeaveAdminModeOnClose && !IsShuttingDown)
+            {
+                ToUserMode();
+            }
+        }
+
+        private void InactivityMonitor_Elapsed(object sender, ElapsedEventArgs e)
+        {
+            ToUserMode();
+            inactivityMonitor.Reset();
+        }
     }
 }

--- a/Up2dateService/Up2dateConsole/Session/Session.cs
+++ b/Up2dateService/Up2dateConsole/Session/Session.cs
@@ -101,6 +101,12 @@ namespace Up2dateConsole.Session
             }
         }
 
+        public void OnWindowsSessionEnding()
+        {
+            IsShuttingDown = true;
+            ShuttingDown?.Invoke(this, EventArgs.Empty);
+        }
+
         private void InactivityMonitor_Elapsed(object sender, ElapsedEventArgs e)
         {
             ToUserMode();

--- a/Up2dateService/Up2dateConsole/Up2dateConsole.csproj
+++ b/Up2dateService/Up2dateConsole/Up2dateConsole.csproj
@@ -114,6 +114,8 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
     </Compile>
+    <Compile Include="Session\ISession.cs" />
+    <Compile Include="Session\Session.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="StateIndicator\StateIndicatorViewModel.cs" />
     <Compile Include="StateIndicator\StateIndicator.xaml.cs">

--- a/Up2dateService/Up2dateConsole/Up2dateConsole.csproj
+++ b/Up2dateService/Up2dateConsole/Up2dateConsole.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Helpers\SingleInstanceHelper.cs" />
     <Compile Include="ISettings.cs" />
     <Compile Include="IWcfClientFactory.cs" />
+    <Compile Include="Logger.cs" />
     <Compile Include="Properties\Resources.ru-RU.Designer.cs">
       <DependentUpon>Resources.ru-RU.resx</DependentUpon>
       <AutoGen>True</AutoGen>
@@ -270,9 +271,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
       <Version>7.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="NLog">
-      <Version>5.0.5</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Proposed Changes

  - Block restart if application is explicitly shutting down
  - Don't restart timer when shutting down
  - Handle windows session ending (system shutdown or user logoff)
  - Get rid of NLOG as it appeared to create problem accessing named pipes
  - Refactor for better maintainability and testability
    - Move shutdown and admin/user mode switch support out of MainWindowViewModel into separate Session class
    - Move handling of OnWindowClosing from MainWindowViewModel to Session
    - Move main window viewmodel creation to App.cs